### PR TITLE
`prelaunchTask` is not able to find a `Build` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "publisher": "astronachos",
   "name": "defold",
   "contributesPrefix": "defoldKit",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "license": "MIT",
   "displayName": "Defold Kit",
   "description": "Toolkit to build, launch, debug, bundle and deploy your game made with Defold",
@@ -107,7 +107,7 @@
         "category": "Defold Kit",
         "icon": "$(package)",
         "title": "Build",
-        "enablement": "false"
+        "enablement": "workspaceFolderCount > 0"
       }
     ],
     "configuration": [

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -37,7 +37,7 @@ export const buildTaskName = 'Build to Launch'
 
 export function makeTasks(): vscode.Task[] {
 	return [
-		makeTask(buildTaskName, 'build', undefined),
+		makeTask(buildTaskName, 'build', vscode.TaskGroup.Build),
 		makeTask('Bundle', 'bundle', vscode.TaskGroup.Build),
 		makeTask('Clean Build', 'cleanBuild', vscode.TaskGroup.Build),
 		makeTask('Resolve Dependencies', 'resolve', vscode.TaskGroup.Build),


### PR DESCRIPTION
Hey, Roman! 
Was trying to prepare to the upcoming crazy-games-x-defold jam and faced this issue.
![Image](https://github.com/user-attachments/assets/37308460-00c5-4438-b0e0-e3678d1f56db)

Maybe it's better to expose `Build` command into UI for now?